### PR TITLE
fix breaking changes to run on flutter 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ https://pub.dartlang.org/packages/flutter_neumorphic)
 
 ```dart
 dependencies:
-  flutter_neumorphic: ^3.0.3
+  neumorphic_ui: ^3.0.3
 
 //requires flutter > 1.13.18
 ```

--- a/lib/src/widget/app.dart
+++ b/lib/src/widget/app.dart
@@ -88,8 +88,8 @@ class NeumorphicApp extends StatelessWidget {
       primaryColor: theme.accentColor,
       iconTheme: theme.iconTheme,
       brightness: ThemeData.estimateBrightnessForColor(theme.baseColor),
-      primaryColorBrightness:
-          ThemeData.estimateBrightnessForColor(theme.accentColor),
+      // primaryColorBrightness:
+      //     ThemeData.estimateBrightnessForColor(theme.accentColor),
       textTheme: theme.textTheme,
       scaffoldBackgroundColor: theme.baseColor, colorScheme: ColorScheme.fromSwatch().copyWith(secondary: theme.variantColor),
     );


### PR DESCRIPTION
After `flutter upgrade` from 3.10 to 3.13, No longer `ThemeData` has an argument for `primaryColorBrightness`.

I remove it and my app can run on flutter 3.13.